### PR TITLE
Relax the containers boundary for ghc 7.6

### DIFF
--- a/lattices.cabal
+++ b/lattices.cabal
@@ -16,6 +16,6 @@ Library
                          Algebra.Lattice.Levitated,
                          Algebra.Lattice.Lifted,
                          Algebra.PartialOrd
-                         
+
         Build-Depends:   base >= 3 && < 5,
-                         containers >= 0.3 && < 0.5
+                         containers >= 0.3 && < 0.6


### PR DESCRIPTION
Fixes compilation with ghc 7.6 and doesn't seem to cause any problems
