### PR TITLE
Replace empty classes with synonyms

### DIFF
--- a/Algebra/Lattice.hs
+++ b/Algebra/Lattice.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, ConstraintKinds #-}
 module Algebra.Lattice (
     -- * Unbounded lattices
     JoinSemiLattice(..), MeetSemiLattice(..), Lattice,
@@ -58,7 +58,7 @@ meets1 = foldr1 meet
 -- see <http://en.wikipedia.org/wiki/Absorption_law> and <http://en.wikipedia.org/wiki/Lattice_(order)>
 --
 -- Absorption: a `join` (a `meet` b) == a `meet` (a `join` b) == a
-class (JoinSemiLattice a, MeetSemiLattice a) => Lattice a where
+type Lattice a = (JoinSemiLattice a, MeetSemiLattice a)
 
 -- | A join-semilattice with some element |bottom| that `join` approaches.
 --
@@ -82,7 +82,7 @@ meets = foldr meet top
 
 
 -- | Lattices with both bounds
-class (Lattice a, BoundedJoinSemiLattice a, BoundedMeetSemiLattice a) => BoundedLattice a where
+type BoundedLattice a = (Lattice a, BoundedJoinSemiLattice a, BoundedMeetSemiLattice a)
 
 
 --
@@ -95,15 +95,11 @@ instance Ord a => JoinSemiLattice (S.Set a) where
 instance (Ord a, Enumerable a) => MeetSemiLattice (S.Set (Enumerated a)) where
     meet = S.intersection
 
-instance (Ord a, Enumerable a) => Lattice (S.Set (Enumerated a)) where
-
 instance Ord a => BoundedJoinSemiLattice (S.Set a) where
     bottom = S.empty
 
 instance (Ord a, Enumerable a) => BoundedMeetSemiLattice (S.Set (Enumerated a)) where
     top = S.fromList universe
-
-instance (Ord a, Enumerable a) => BoundedLattice (S.Set (Enumerated a)) where
 
 --
 -- IntSets
@@ -125,15 +121,11 @@ instance (Ord k, JoinSemiLattice v) => JoinSemiLattice (M.Map k v) where
 instance (Ord k, Enumerable k, MeetSemiLattice v) => MeetSemiLattice (M.Map (Enumerated k) v) where
     meet = M.intersectionWith meet
 
-instance (Ord k, Enumerable k, Lattice v) => Lattice (M.Map (Enumerated k) v) where
-
 instance (Ord k, JoinSemiLattice v) => BoundedJoinSemiLattice (M.Map k v) where
     bottom = M.empty
 
 instance (Ord k, Enumerable k, BoundedMeetSemiLattice v) => BoundedMeetSemiLattice (M.Map (Enumerated k) v) where
     top = M.fromList (universe `zip` repeat top)
-
-instance (Ord k, Enumerable k, BoundedLattice v) => BoundedLattice (M.Map (Enumerated k) v) where
 
 --
 -- IntMaps
@@ -155,15 +147,11 @@ instance JoinSemiLattice v => JoinSemiLattice (k -> v) where
 instance MeetSemiLattice v => MeetSemiLattice (k -> v) where
     f `meet` g = \x -> f x `meet` g x
 
-instance Lattice v => Lattice (k -> v) where
-
 instance BoundedJoinSemiLattice v => BoundedJoinSemiLattice (k -> v) where
     bottom = const bottom
 
 instance BoundedMeetSemiLattice v => BoundedMeetSemiLattice (k -> v) where
     top = const top
-
-instance BoundedLattice v => BoundedLattice (k -> v) where
 
 --
 -- Tuples
@@ -175,15 +163,11 @@ instance (JoinSemiLattice a, JoinSemiLattice b) => JoinSemiLattice (a, b) where
 instance (MeetSemiLattice a, MeetSemiLattice b) => MeetSemiLattice (a, b) where
     (x1, y1) `meet` (x2, y2) = (x1 `meet` x2, y1 `meet` y2)
 
-instance (Lattice a, Lattice b) => Lattice (a, b) where
-
 instance (BoundedJoinSemiLattice a, BoundedJoinSemiLattice b) => BoundedJoinSemiLattice (a, b) where
     bottom = (bottom, bottom)
 
 instance (BoundedMeetSemiLattice a, BoundedMeetSemiLattice b) => BoundedMeetSemiLattice (a, b) where
     top = (top, top)
-
-instance (BoundedLattice a, BoundedLattice b) => BoundedLattice (a, b) where
 
 --
 -- Bools
@@ -195,16 +179,11 @@ instance JoinSemiLattice Bool where
 instance MeetSemiLattice Bool where
     meet = (&&)
 
-instance Lattice Bool where
-
 instance BoundedJoinSemiLattice Bool where
     bottom = False
 
 instance BoundedMeetSemiLattice Bool where
     top = True
-
-instance BoundedLattice Bool where
-
 
 -- | Implementation of Kleene fixed-point theorem <http://en.wikipedia.org/wiki/Kleene_fixed-point_theorem>.
 -- Assumes that the function is monotone and does not check if that is correct.

--- a/Algebra/Lattice/Dropped.hs
+++ b/Algebra/Lattice/Dropped.hs
@@ -23,12 +23,8 @@ instance MeetSemiLattice a => MeetSemiLattice (Dropped a) where
     drop_x `meet` Top    = drop_x
     Drop x `meet` Drop y = Drop (x `meet` y)
 
-instance Lattice a => Lattice (Dropped a) where
-
 instance BoundedJoinSemiLattice a => BoundedJoinSemiLattice (Dropped a) where
     bottom = Drop bottom
 
 instance MeetSemiLattice a => BoundedMeetSemiLattice (Dropped a) where
     top = Top
-
-instance BoundedLattice a => BoundedLattice (Dropped a) where

--- a/Algebra/Lattice/Levitated.hs
+++ b/Algebra/Lattice/Levitated.hs
@@ -29,12 +29,8 @@ instance MeetSemiLattice a => MeetSemiLattice (Levitated a) where
     Bottom     `meet` _          = Bottom
     _          `meet` Bottom     = Bottom
 
-instance Lattice a => Lattice (Levitated a) where
-
 instance JoinSemiLattice a => BoundedJoinSemiLattice (Levitated a) where
     bottom = Bottom
 
 instance MeetSemiLattice a => BoundedMeetSemiLattice (Levitated a) where
     top = Top
-
-instance BoundedLattice a => BoundedLattice (Levitated a) where

--- a/Algebra/Lattice/Lifted.hs
+++ b/Algebra/Lattice/Lifted.hs
@@ -23,12 +23,8 @@ instance MeetSemiLattice a => MeetSemiLattice (Lifted a) where
     Bottom `meet` _      = Bottom
     _      `meet` Bottom = Bottom
 
-instance Lattice a => Lattice (Lifted a) where
-
 instance JoinSemiLattice a => BoundedJoinSemiLattice (Lifted a) where
     bottom = Bottom
 
 instance BoundedMeetSemiLattice a => BoundedMeetSemiLattice (Lifted a) where
     top = Lift top
-
-instance BoundedLattice a => BoundedLattice (Lifted a) where

--- a/lattices.cabal
+++ b/lattices.cabal
@@ -1,6 +1,6 @@
 Name:               lattices
-Version:            1.2.1
-Cabal-Version:      >= 1.2
+Version:            1.3.0
+Cabal-Version:      >= 1.10
 Category:           Math
 Synopsis:           Fine-grained library for constructing and manipulating lattices
 License:            BSD3
@@ -17,7 +17,8 @@ Library
                           Algebra.Lattice.Lifted,
                           Algebra.PartialOrd
 
-        Other-Extensions: FlexibleInstances
+        Other-Extensions: FlexibleInstances,
+                          ConstraintKinds
 
         Build-Depends:    base >= 3 && < 5,
                           containers >= 0.3 && < 0.6

--- a/lattices.cabal
+++ b/lattices.cabal
@@ -10,12 +10,14 @@ Maintainer:         Max Bolingbroke <batterseapower@hotmail.com>
 Build-Type:         Simple
 
 Library
-        Exposed-Modules: Algebra.Enumerable,
-                         Algebra.Lattice,
-                         Algebra.Lattice.Dropped,
-                         Algebra.Lattice.Levitated,
-                         Algebra.Lattice.Lifted,
-                         Algebra.PartialOrd
+        Exposed-Modules:  Algebra.Enumerable,
+                          Algebra.Lattice,
+                          Algebra.Lattice.Dropped,
+                          Algebra.Lattice.Levitated,
+                          Algebra.Lattice.Lifted,
+                          Algebra.PartialOrd
 
-        Build-Depends:   base >= 3 && < 5,
-                         containers >= 0.3 && < 0.6
+        Other-Extensions: FlexibleInstances
+
+        Build-Depends:    base >= 3 && < 5,
+                          containers >= 0.3 && < 0.6


### PR DESCRIPTION
I don't know if you want this, since it breaks compatibility and requires a new(_ish_) GHC, but in case you're interested: replaces things of the form

```
class (A a, B a) => C a
```

with

```
type C a = (A a, B a)
```
